### PR TITLE
fix: quotations in charset parameter

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/http/CharsetExtractor.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/http/CharsetExtractor.groovy
@@ -25,7 +25,7 @@ class CharsetExtractor {
 
     private static final String CHARSET = "charset"
 
-    public static String getCharsetFromContentType(String contentType) { 
+    public static String getCharsetFromContentType(String contentType) {
         def foundCharset = null
         if(isBlank(contentType)) {
             foundCharset = null;
@@ -35,6 +35,9 @@ class CharsetExtractor {
                     def questionMark = it.split("=")
                     if(questionMark != null && questionMark.length == 2 && questionMark[0].trim().equalsIgnoreCase("charset")) {
                         foundCharset = questionMark[1]?.trim();
+                        //remove quotations if present
+                        foundCharset = StringUtils.removeStart(foundCharset, "\"")
+                        foundCharset = StringUtils.removeEnd(foundCharset, "\"")
                     }
                 }
             }

--- a/rest-assured/src/test/groovy/com/jayway/restassured/internal/http/CharsetExtractorTest.groovy
+++ b/rest-assured/src/test/groovy/com/jayway/restassured/internal/http/CharsetExtractorTest.groovy
@@ -16,13 +16,18 @@ class CharsetExtractorTest {
         assertEquals "UTF-8", CharsetExtractor.getCharsetFromContentType("application/ld+json; qs=0.5; charset=UTF-8")
     }
 
-  @Test
-  def void shouldExtractCharsetFromTheEndOfTheDeclarationWhenCharsetIsNotLowercase() throws Exception {
-    assertEquals "UTF-8", CharsetExtractor.getCharsetFromContentType("application/ld+json; qs=0.5; CharseT=UTF-8")
-  }
+    @Test
+    def void shouldExtractCharsetFromTheEndOfTheDeclarationWhenCharsetIsNotLowercase() throws Exception {
+      assertEquals "UTF-8", CharsetExtractor.getCharsetFromContentType("application/ld+json; qs=0.5; CharseT=UTF-8")
+    }
 
     @Test
     def void shouldExtractNullCharsetWhenNotPresent() throws Exception {
         assertEquals null, CharsetExtractor.getCharsetFromContentType("application/ld+json; qs=0.5")
+    }
+
+    @Test
+    def void shouldExtractCharsetIfQuoted() throws Exception {
+        assertEquals "UTF-8", CharsetExtractor.getCharsetFromContentType("application/ld+json; charset=\"UTF-8\"")
     }
 }


### PR DESCRIPTION
-charsets that are quoted will now be recognized by removing the quotes, so that e.g. charset="UTF-8" works

Solves Issue 413