### PR TITLE
fix #592 GPath namespace handling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,20 @@ Change log next version
 * It's now possible to specify default mime subtype for multipart content-type. Use the MultiPartConfig#defaultSubtype(..) method.
   Default is "form-data" which results in a content-type of "multipart/form-data". This also works for the MockMvc module.
 * Upgraded JUnit to 4.12
+* fix evaluation of GPath expression from root if xml namespaces are declared (issue 592). For example given the following XML:
+      <foo xmlns:ns="http://localhost/">
+         <bar>sudo </bar>
+         <ns:bar>make me a sandwich!</ns:bar>
+      </foo>
+  you can verify it like this:
+      given().
+              config(newConfig().xmlConfig(xmlConfig().declareNamespace("ns", "http://localhost/"))).
+      expect().
+              body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+              body(":foo.:bar.text()", equalTo("sudo ")).
+              body(":foo.ns:bar.text()", equalTo("make me a sandwich!")).
+      when().
+              get("/namespace-example");
 
 Change log 2.5.0 (2015-08-09)
 -----------------------------

--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/GivenWhenThenNamespaceITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/GivenWhenThenNamespaceITest.java
@@ -37,9 +37,9 @@ public class GivenWhenThenNamespaceITest extends WithJetty {
         when().
                   get("/namespace-example").
         then().
-                  body("bar.text()", equalTo("sudo make me a sandwich!")).
-                  body(":bar.text()", equalTo("sudo ")).
-                  body("ns:bar.text()", equalTo("make me a sandwich!"));
+                  body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+                  body(":foo.:bar.text()", equalTo("sudo ")).
+                  body(":foo.ns:bar.text()", equalTo("make me a sandwich!"));
     }
 
     @Test public void

--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/NamespaceExpectationsITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/NamespaceExpectationsITest.java
@@ -34,9 +34,9 @@ public class NamespaceExpectationsITest extends WithJetty {
         given().
                 config(newConfig().xmlConfig(xmlConfig().declareNamespace("ns", "http://localhost/"))).
         expect().
-                body("bar.text()", equalTo("sudo make me a sandwich!")).
-                body(":bar.text()", equalTo("sudo ")).
-                body("ns:bar.text()", equalTo("make me a sandwich!")).
+                body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+                body(":foo.:bar.text()", equalTo("sudo ")).
+                body("foo.ns:bar.text()", equalTo("make me a sandwich!")).
         when().
                 get("/namespace-example");
     }
@@ -46,9 +46,9 @@ public class NamespaceExpectationsITest extends WithJetty {
         given().
                 config(newConfig().xmlConfig(xmlConfig().declareNamespace("test", "http://localhost/"))).
         expect().
-                body("bar.text()", equalTo("sudo make me a sandwich!")).
-                body(":bar.text()", equalTo("sudo ")).
-                body("test:bar.text()", equalTo("make me a sandwich!")).
+                body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+                body(":foo.:bar.text()", equalTo("sudo ")).
+                body("foo.test:bar.text()", equalTo("make me a sandwich!")).
         when().
                 get("/namespace-example");
     }
@@ -56,9 +56,9 @@ public class NamespaceExpectationsITest extends WithJetty {
     @Test public void
     doesnt_take_namespaces_into_account_when_no_namespace_is_declared() {
         expect().
-                body("bar.text()", equalTo("sudo make me a sandwich!")).
-                body(":bar.text()", equalTo("sudo make me a sandwich!")).
-                body("ns:bar.text()", equalTo("sudo make me a sandwich!")).
+                body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+                body(":foo.:bar.text()", equalTo("sudo ")).
+                body("foo.ns:bar.text()", equalTo("")).
         when().
                 get("/namespace-example");
     }
@@ -68,9 +68,9 @@ public class NamespaceExpectationsITest extends WithJetty {
         given().
                 config(newConfig().xmlConfig(xmlConfig().namespaceAware(true))).
         expect().
-                body("bar.text()", equalTo("sudo make me a sandwich!")).
-                body(":bar.text()", equalTo("sudo make me a sandwich!")).
-                body("ns:bar.text()", equalTo("sudo make me a sandwich!")).
+                body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+                body(":foo.:bar.text()", equalTo("sudo ")).
+                body("foo.ns:bar.text()", equalTo("")).
         when().
                 get("/namespace-example");
     }
@@ -80,9 +80,9 @@ public class NamespaceExpectationsITest extends WithJetty {
         given().
                 config(newConfig().xmlConfig(xmlConfig().declareNamespace("ns", "http://something.com"))).
         expect().
-                body("bar.text()", equalTo("sudo make me a sandwich!")).
-                body(":bar.text()", equalTo("sudo ")).
-                body("ns:bar.text()", isEmptyString()).
+                body("foo.bar.text()", equalTo("sudo make me a sandwich!")).
+                body(":foo.:bar.text()", equalTo("sudo ")).
+                body("foo.ns:bar.text()", isEmptyString()).
         when().
                 get("/namespace-example");
     }

--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/NamespaceResponseParsingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/NamespaceResponseParsingITest.java
@@ -38,26 +38,26 @@ public class NamespaceResponseParsingITest extends WithJetty {
         when().
                 get("/namespace-example").xmlPath();
 
-        assertThat(xmlPath.getString("bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString(":bar.text()"), equalTo("sudo "));
-        assertThat(xmlPath.getString("ns:bar.text()"), equalTo("make me a sandwich!"));
+        assertThat(xmlPath.getString("foo.bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString(":foo.:bar.text()"), equalTo("sudo "));
+        assertThat(xmlPath.getString("foo.ns:bar.text()"), equalTo("make me a sandwich!"));
     }
 
     @Test public void
     doesnt_take_namespaces_into_account_when_no_namespace_is_declared() {
         XmlPath xmlPath = get("/namespace-example").xmlPath();
 
-        assertThat(xmlPath.getString("bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString(":bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString("ns:bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString("foo.bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString(":foo.:bar.text()"), equalTo("sudo "));
+        assertThat(xmlPath.getString("foo.ns:bar.text()"), equalTo(""));
     }
 
     @Test public void
     takes_namespaces_into_when_passing_xml_path_config_to_xml_path_method_in_response_object() {
         final XmlPath xmlPath = get("/namespace-example").xmlPath(xmlPathConfig().with().declaredNamespace("ns", "http://localhost/"));
 
-        assertThat(xmlPath.getString("bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString(":bar.text()"), equalTo("sudo "));
-        assertThat(xmlPath.getString("ns:bar.text()"), equalTo("make me a sandwich!"));
+        assertThat(xmlPath.getString("foo.bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString(":foo.:bar.text()"), equalTo("sudo "));
+        assertThat(xmlPath.getString("foo.ns:bar.text()"), equalTo("make me a sandwich!"));
     }
 }

--- a/xml-path/src/main/groovy/com/jayway/restassured/assertion/XMLAssertion.groovy
+++ b/xml-path/src/main/groovy/com/jayway/restassured/assertion/XMLAssertion.groovy
@@ -103,8 +103,7 @@ class XMLAssertion implements Assertion {
     }
 
     def Object getResult(object, config) {
-        boolean isRoot = config.getXmlConfig()?.declaredNamespaces()?.isEmpty() // Be root if no namespaces are declared
-        return getResult(object, true, isRoot)
+        return getResult(object, true, true)
     }
 
     def Object getChildResultAsJavaObject(Object object) {

--- a/xml-path/src/main/java/com/jayway/restassured/path/xml/XmlPath.java
+++ b/xml-path/src/main/java/com/jayway/restassured/path/xml/XmlPath.java
@@ -430,7 +430,7 @@ public class XmlPath {
         }
         final String root = rootPath.equals("") ? rootPath : rootPath.endsWith(".") ? rootPath : rootPath + ".";
         xmlAssertion.setKey(root + path);
-        return (T) xmlAssertion.getResult(input, convertToJavaObject, !getXmlPathConfig().hasDeclaredNamespaces());
+        return (T) xmlAssertion.getResult(input, convertToJavaObject, true);
     }
 
     /**

--- a/xml-path/src/test/java/com/jayway/restassured/path/xml/XmlPathNamespaceTest.java
+++ b/xml-path/src/test/java/com/jayway/restassured/path/xml/XmlPathNamespaceTest.java
@@ -36,9 +36,9 @@ public class XmlPathNamespaceTest {
         XmlPath xmlPath = new XmlPath(xml).using(xmlPathConfig().declaredNamespace("ns", "http://localhost/"));
 
         // Then
-        assertThat(xmlPath.getString("bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString(":bar.text()"), equalTo("sudo "));
-        assertThat(xmlPath.getString("ns:bar.text()"), equalTo("make me a sandwich!"));
+        assertThat(xmlPath.getString("foo.bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString(":foo.:bar.text()"), equalTo("sudo "));
+        assertThat(xmlPath.getString(":foo.ns:bar.text()"), equalTo("make me a sandwich!"));
     }
 
     @Test public void
@@ -53,8 +53,8 @@ public class XmlPathNamespaceTest {
         XmlPath xmlPath = new XmlPath(xml);
 
         // Then
-        assertThat(xmlPath.getString("bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString(":bar.text()"), equalTo("sudo make me a sandwich!"));
-        assertThat(xmlPath.getString("ns:bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString("foo.bar.text()"), equalTo("sudo make me a sandwich!"));
+        assertThat(xmlPath.getString(":foo.:bar.text()"), equalTo("sudo "));
+        assertThat(xmlPath.getString(":foo.ns:bar.text()"), equalTo(""));
     }
 }


### PR DESCRIPTION
fixes #592 by always resolving an gpath from the root. Also updates various related unit tests that used to "accidentially" pass incorrectly 