### PR TITLE
Fix for #544

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/GetWithContentITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/GetWithContentITest.java
@@ -1,0 +1,14 @@
+package com.jayway.restassured.itest.java;
+
+import com.jayway.restassured.itest.java.support.WithJetty;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+
+public class GetWithContentITest extends WithJetty {
+
+    @Test public void
+    get_method_with_content() {
+        given().body("hullo").expect().statusCode(200).when().get("/getWithContent");
+    }
+}

--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/JSONGetITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/JSONGetITest.java
@@ -292,14 +292,6 @@ public class JSONGetITest extends WithJetty {
     }
 
     @Test
-    public void getDoesntSupportsStringBody() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Cannot set a request body for a GET method");
-
-        given().body("a body").expect().body(equalTo("a body")).when().get("/body");
-    }
-
-    @Test
     public void supportsGettingListSize() throws Exception {
         expect().body("store.book.category.size()", equalTo(4)).when().get("/jsonStore");
     }

--- a/examples/scala-example/pom.xml
+++ b/examples/scala-example/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>1.3.0</version>
+            <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/scala-example/src/test/scala/com.jayway.restassured.scala/ScalaITest.scala
+++ b/examples/scala-example/src/test/scala/com.jayway.restassured.scala/ScalaITest.scala
@@ -29,7 +29,7 @@ class ScalaITest {
   @Before
   def `Mock web server is initialized`() {
     webServer = new MockWebServer()
-    webServer.play()
+    webServer.start()
   }
 
   @After

--- a/examples/scalatra-example/src/main/scala/com/jayway/restassured/scalatra/ScalatraRestExample.scala
+++ b/examples/scalatra-example/src/main/scala/com/jayway/restassured/scalatra/ScalatraRestExample.scala
@@ -57,6 +57,15 @@ class ScalatraRestExample extends ScalatraServlet {
     compact(render(json))
   }
 
+  get("/getWithContent") {
+    if (request.body == "hullo") {
+      status = 200
+    } else {
+      status = 400
+      "No or incorrect content"
+    }
+  }
+
   get("/greetXML") {
     greetXML
   }

--- a/rest-assured/src/main/java/com/jayway/restassured/internal/http/HttpGetWithBody.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/internal/http/HttpGetWithBody.java
@@ -1,0 +1,35 @@
+package com.jayway.restassured.internal.http;
+
+import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+@NotThreadSafe
+public class HttpGetWithBody extends HttpEntityEnclosingRequestBase {
+
+    public final static String METHOD_NAME = "GET";
+
+    public HttpGetWithBody() {
+        super();
+    }
+
+    public HttpGetWithBody(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    /**
+     * @throws IllegalArgumentException if the uri is invalid.
+     */
+    public HttpGetWithBody(final String uri) {
+        super();
+        setURI(URI.create(uri));
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+
+}

--- a/rest-assured/src/main/java/com/jayway/restassured/internal/http/Method.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/internal/http/Method.java
@@ -25,7 +25,7 @@ import org.apache.http.client.methods.*;
  * @author Johan Haleby
  */
 public enum Method {
-	GET( HttpGet.class ), 
+	GET( HttpGetWithBody.class ),
 	PUT( HttpPut.class ), 
 	POST( HttpPost.class ), 
 	DELETE( HttpDeleteWithBody.class ),


### PR DESCRIPTION
I added support for a GET request body. I also had to update the com.squareup.okhttp.mockwebserver dependency; in the older version the mockserver checks, if the GET request has a body and then it throws an exception. In the new version this behavior has changed.