### PR TITLE
Fix for #566

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/ContentTypeITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/ContentTypeITest.java
@@ -341,6 +341,14 @@ public class ContentTypeITest extends WithJetty {
                 post("/textUriList");
     }
 
+    @Test public void
+    validates_content_type_even_when_it_is_a_204_response() {
+        given().post("/return204WithContentType")
+                .then()
+                .statusCode(204)
+                .contentType(ContentType.JSON);
+    }
+
     private String toJetty9(String charset) {
         return StringUtils.lowerCase(StringUtils.remove(charset, " "));
     }

--- a/examples/scalatra-example/src/main/scala/com/jayway/restassured/scalatra/ScalatraRestExample.scala
+++ b/examples/scalatra-example/src/main/scala/com/jayway/restassured/scalatra/ScalatraRestExample.scala
@@ -1141,6 +1141,11 @@ class ScalatraRestExample extends ScalatraServlet {
       request.getContentType
   }
 
+  post("/return204WithContentType") {
+    contentType = "application/json"
+    status = 204
+  }
+
   def formAuth(loginPage: () => String) = {
     contentType = "text/plain"
     val cookies: Array[Cookie] = request.getCookies

--- a/rest-assured/src/main/java/com/jayway/restassured/internal/http/HttpResponseContentTypeFinder.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/internal/http/HttpResponseContentTypeFinder.java
@@ -16,6 +16,8 @@
 
 package com.jayway.restassured.internal.http;
 
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 
 /**
@@ -29,12 +31,12 @@ public class HttpResponseContentTypeFinder {
      * @param resp
      */
     public static String findContentType(HttpResponse resp) {
-        if ( resp.getEntity() == null )
-            throw new IllegalArgumentException( "Response does not contain data" );
-        if ( resp.getEntity().getContentType() == null )
+        Header contentTypeHeader = resp.getFirstHeader(HttpHeaders.CONTENT_TYPE);
+
+        if ( contentTypeHeader == null )
             throw new IllegalArgumentException( "Response does not have a content-type header" );
         try {
-            return resp.getEntity().getContentType().getValue();
+            return contentTypeHeader.getValue();
         }
         catch ( RuntimeException ex ) {  // NPE or OOB Exceptions
             throw new IllegalArgumentException( "Could not parse content-type from response" );


### PR DESCRIPTION
Response content-type validation now works correctly, even if the response body is empty.