### PR TITLE
Modify HttpClientConfig so parameter methods respect previous configuration. Fixes #612

### DIFF
--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -121,7 +121,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rest-assured/src/main/java/com/jayway/restassured/config/HttpClientConfig.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/config/HttpClientConfig.java
@@ -177,7 +177,7 @@ import static java.util.Arrays.asList;
         notNull(parameterName, "Parameter name");
         final Map<String, Object> newParams = new HashMap<String, Object>(httpClientParams);
         newParams.put(parameterName, parameterValue);
-        return new HttpClientConfig(newParams);
+        return new HttpClientConfig(httpClientFactory, newParams, httpMultipartMode, shouldReuseHttpClientInstance, NO_HTTP_CLIENT, true);
     }
 
     /**
@@ -187,7 +187,7 @@ import static java.util.Arrays.asList;
      * @return An updated HttpClientConfig
      */
     public HttpClientConfig withParams(Map<String, ?> httpClientParams) {
-        return new HttpClientConfig(httpClientParams);
+        return new HttpClientConfig(httpClientFactory, httpClientParams, httpMultipartMode, shouldReuseHttpClientInstance, NO_HTTP_CLIENT, true);
     }
 
     /**
@@ -208,9 +208,9 @@ import static java.util.Arrays.asList;
      */
     public HttpClientConfig addParams(Map<String, ?> httpClientParams) {
         notNull(httpClientParams, "httpClientParams");
-        final Map<String, Object> newParams = new HashMap<String, Object>(httpClientParams);
+        final Map<String, Object> newParams = new HashMap<String, Object>(this.httpClientParams);
         newParams.putAll(httpClientParams);
-        return new HttpClientConfig(newParams);
+        return new HttpClientConfig(httpClientFactory, newParams, httpMultipartMode, shouldReuseHttpClientInstance, NO_HTTP_CLIENT, true);
     }
 
     /**

--- a/rest-assured/src/test/java/com/jayway/restassured/config/HttpClientConfigTest.java
+++ b/rest-assured/src/test/java/com/jayway/restassured/config/HttpClientConfigTest.java
@@ -20,17 +20,89 @@ import org.apache.http.client.params.ClientPNames;
 import org.apache.http.client.params.CookiePolicy;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.junit.Assert.assertTrue;
 
 public class HttpClientConfigTest {
+
+    private static final String CUSTOM_MAX_REDIRECTS = "100";
 
     @Test
     public void cookiePolicyIsSetToIgnoreCookiesByDefault() throws Exception {
         final HttpClientConfig httpClientConfig = new HttpClientConfig();
 
-        assertThat((Map<String,String>) httpClientConfig.params(), hasEntry(ClientPNames.COOKIE_POLICY, CookiePolicy.IGNORE_COOKIES));
+        assertThat(httpClientConfig.params())
+                .contains(entry(ClientPNames.COOKIE_POLICY, CookiePolicy.IGNORE_COOKIES));
     }
+
+    @Test
+    public void setParamsRespectsOtherConfigurationSettings() {
+        final HttpClientConfig httpClientConfig = new HttpClientConfig()
+                .setParam(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS)
+                .reuseHttpClientInstance()
+                .setParam(ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY);
+
+        assertThat(httpClientConfig.params())
+                .contains(
+                        entry(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS),
+                        entry(ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY)
+                );
+        assertTrue(httpClientConfig.isConfiguredToReuseTheSameHttpClientInstance());
+
+    }
+
+    @Test
+    public void setParamsCorrectlyUpdatesPreviousSetting() {
+        final HttpClientConfig httpClientConfig = new HttpClientConfig()
+                .setParam(ClientPNames.MAX_REDIRECTS, "50")
+                .setParam(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS);
+
+        assertThat(httpClientConfig.params())
+                .contains(entry(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS));
+    }
+
+    @Test
+    public void addParamsRespectsOtherConfigurationSettings() {
+        final Map<String, String> redirectParam = new HashMap<String, String>();
+        final Map<String, String> cookieParam = new HashMap<String, String>();
+
+        redirectParam.put(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS);
+        cookieParam.put(ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY);
+
+        final HttpClientConfig httpClientConfig = new HttpClientConfig()
+                .addParams(redirectParam)
+                .reuseHttpClientInstance()
+                .addParams(cookieParam);
+
+        assertThat(httpClientConfig.params())
+                .contains(
+                        entry(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS),
+                        entry(ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY)
+                );
+        assertTrue(httpClientConfig.isConfiguredToReuseTheSameHttpClientInstance());
+
+    }
+
+    @Test
+    public void addParamCorrectlyUpdatesPreviousSetting() {
+        final Map<String, String> redirectParam = new HashMap<String, String>();
+        final Map<String, String> cookieParam = new HashMap<String, String>();
+
+        redirectParam.put(ClientPNames.MAX_REDIRECTS, "50");
+        cookieParam.put(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS);
+
+        final HttpClientConfig httpClientConfig = new HttpClientConfig()
+                .addParams(redirectParam)
+                .reuseHttpClientInstance()
+                .addParams(cookieParam);
+
+        assertThat(httpClientConfig.params())
+                .contains(entry(ClientPNames.MAX_REDIRECTS, CUSTOM_MAX_REDIRECTS));
+
+    }
+
 }


### PR DESCRIPTION
Alterations to HttpClientConfig to address issue referenced in issue [https://github.com/jayway/rest-assured/issues/612] 

I added a few tests to make sure this was behaving as expected now and all is fine. Also addressed the bug with the addParams method only setting the new parameters, not merging them with existing ones