### PR TITLE
CookieFilter

### DIFF
--- a/rest-assured/src/main/java/com/jayway/restassured/filter/cookie/CookieFilter.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/filter/cookie/CookieFilter.java
@@ -1,0 +1,56 @@
+package com.jayway.restassured.filter.cookie;
+
+import com.jayway.restassured.filter.Filter;
+import com.jayway.restassured.filter.FilterContext;
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.specification.FilterableRequestSpecification;
+import com.jayway.restassured.specification.FilterableResponseSpecification;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The cookie filter can be used to keep track of all the cookies sent by the server and use them in subsequent requests.
+ * It might come in handy when more than just the {@link com.jayway.restassured.filter.session.SessionFilter} is needed.
+ * For example:
+ * <pre>
+ * CookieFilter cookieFilter = new CookieFilter();
+ *
+ * given().
+ *         filter(cookieFilter).
+ * expect().
+ *         statusCode(200).
+ * when().
+ *         get("/x");
+ *
+ * given().
+ *         cookie("foo", "bar").
+ *         filter(cookieFilter). // Reuse the same cookie filter
+ *                               // if "foo" is stored in cookieFilter it won't be applied because it's already applied explicitly
+ * expect().
+ *         statusCode(200).
+ * when().
+ *         get("/y");
+ * </pre>
+ */
+public class CookieFilter implements Filter {
+
+    private Map<String, String> cookies = new HashMap<String, String>();
+
+    public Response filter(FilterableRequestSpecification requestSpec, FilterableResponseSpecification responseSpec, FilterContext ctx) {
+
+        // add all previously stored cookies to subsequent requests
+        // but only if they're not already in the request spec
+        for (Map.Entry<String, String> cookie : cookies.entrySet()) {
+            if (!requestSpec.getCookies().hasCookieWithName(cookie.getKey())) {
+                requestSpec.cookie(cookie.getKey(), cookie.getValue());
+            }
+        }
+
+        final Response response = ctx.next(requestSpec, responseSpec);
+
+        cookies.putAll(response.getCookies());
+
+        return response;
+    }
+}

--- a/rest-assured/src/test/java/com/jayway/restassured/filter/CookieFilterTest.java
+++ b/rest-assured/src/test/java/com/jayway/restassured/filter/CookieFilterTest.java
@@ -1,0 +1,100 @@
+package com.jayway.restassured.filter;
+
+import com.jayway.restassured.config.RestAssuredConfig;
+import com.jayway.restassured.filter.cookie.CookieFilter;
+import com.jayway.restassured.internal.ResponseSpecificationImpl;
+import com.jayway.restassured.internal.RestAssuredResponseImpl;
+import com.jayway.restassured.internal.http.Method;
+import com.jayway.restassured.response.Cookie;
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.specification.FilterableRequestSpecification;
+import com.jayway.restassured.specification.FilterableResponseSpecification;
+import com.jayway.restassured.specification.RequestSender;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.junit.Assert.assertThat;
+
+
+public class CookieFilterTest {
+
+    private FilterableResponseSpecification response;
+    private FilterableRequestSpecification req;
+
+    @Before
+    public void setUp() {
+        req = (FilterableRequestSpecification) given();
+        response = new ResponseSpecificationImpl("test", null, null, RestAssuredConfig.newConfig(), null);
+    }
+
+    @Test
+    public void storeCookies() {
+        CookieFilter cookieFilter = new CookieFilter();
+
+        response.cookie("foo", "bar");
+        cookieFilter.filter(req, response, new TestFilterContext());
+
+        for (Cookie cookie : req.getCookies()) {
+            assertThat(cookie.getName(), Matchers.is("foo"));
+            assertThat(cookie.getValue(), Matchers.is("bar"));
+        }
+    }
+
+    @Test
+    public void preserveCookies() {
+        CookieFilter cookieFilter = new CookieFilter();
+
+        response.cookie("foo", "bar");
+        req.cookie("foo", "barbar");
+        cookieFilter.filter(req, response, new TestFilterContext());
+
+        for (Cookie cookie : req.getCookies()) {
+            assertThat(cookie.getName(), Matchers.is("foo"));
+            assertThat(cookie.getValue(), Matchers.is("barbar"));
+        }
+    }
+
+    private static class TestFilterContext implements FilterContext {
+        public void setValue(String name, Object value) {
+
+        }
+
+        public <T> T getValue(String name) {
+            return null;
+        }
+
+        public boolean hasValue(String name) {
+            return false;
+        }
+
+        public Response send(RequestSender requestSender) {
+            return null;
+        }
+
+        public Method getRequestMethod() {
+            return null;
+        }
+
+        public String getRequestPath() {
+            return null;
+        }
+
+        public String getOriginalRequestPath() {
+            return null;
+        }
+
+        public String getRequestURI() {
+            return null;
+        }
+
+        public String getCompleteRequestPath() {
+            return null;
+        }
+
+        public Response next(FilterableRequestSpecification request, FilterableResponseSpecification response) {
+            return new RestAssuredResponseImpl();
+        }
+    }
+}


### PR DESCRIPTION
The cookie filter can be used to keep track of all the cookies sent by the server and use them in subsequent requests. It might come in handy when more than just the SessionFilter is needed.